### PR TITLE
Adding action for pvc removal

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,3 @@
+"remove-pvc":
+  "title": "remove-pvc"
+  "description": "Removes unbound pvc's after unit removal."

--- a/src/builders.py
+++ b/src/builders.py
@@ -104,3 +104,12 @@ class MongoBuilder:
         if sidecar:
             spec['containers'].append(self.__make_sidecar_spec__())
         return spec
+
+
+class K8sBuilder:
+
+    def __init__(self, resource):
+        self._resource = resource
+
+    def demolish(self):
+        self._resource.delete()

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,14 +9,15 @@ from ops.main import main
 
 from resources import OCIImageResource
 from wrapper import FrameworkWrapper
-from k8s import K8sPod
+from k8s import K8sPod, K8sPvc
 from observers import (
     ConfigChangeObserver,
+    RemovalObserver,
     StatusObserver,
     RelationObserver,
 )
 from mongodb_interface_provides import MongoDbServer
-from builders import MongoBuilder
+from builders import MongoBuilder, K8sBuilder
 import logging
 
 logger = logging.getLogger()
@@ -44,7 +45,10 @@ class MongoDbCharm(CharmBase):
                 'mongodb-sidecar-image')
 
         self._pod = K8sPod(self._framework_wrapper.app_name)
+        self._pvc = K8sPvc(self._framework_wrapper.app_name)
         self._mongodb = MongoDbServer(self, "mongo")
+
+        self._k8s_builder = K8sBuilder(self._pvc)
 
         delegators = [
             (self.on.start, self.on_config_changed_delegator),
@@ -52,6 +56,7 @@ class MongoDbCharm(CharmBase):
             (self.on.config_changed, self.on_config_changed_delegator),
             (self.on.update_status, self.on_update_status_delegator),
             (self._mongodb.on.new_client, self.on_new_client_delegator),
+            (self.on.remove_pvc_action, self.on_remove_pvc_action_delegator),
         ]
         for delegator in delegators:
             self.framework.observe(delegator[0], delegator[1])
@@ -63,6 +68,15 @@ class MongoDbCharm(CharmBase):
             self._resources,
             self._pod,
             self._mongo_builder).handle(event)
+
+    def on_remove_pvc_action_delegator(self, event):
+        logger.info('on_remove_pvc_action_delegator({})'.format(event))
+        return RemovalObserver(
+            self._framework_wrapper,
+            self._resources,
+            self._pod,
+            self._pvc,
+            self._k8s_builder).handle(event)
 
     def on_new_client_delegator(self, event):
         logger.info('on_relation_changed_delegator({})'.format(event))

--- a/src/k8s.py
+++ b/src/k8s.py
@@ -10,6 +10,9 @@ class K8sApi:
     def get(self, path):
         return self.request('GET', path)
 
+    def delete(self, path):
+        return self.request('DELETE', path)
+
     def request(self, method, path):
         with open("/var/run/secrets/kubernetes.io/serviceaccount/token") \
                 as token_file:
@@ -39,7 +42,7 @@ class K8sPod:
     def fetch(self):
         namespace = os.environ["JUJU_MODEL_NAME"]
 
-        path = f'/api/v1/namespaces/{namespace}/pods?'\
+        path = f'/api/v1/namespaces/{namespace}/pods?' \
                f'labelSelector=juju-app={self._app_name}'
 
         api_server = K8sApi()
@@ -56,6 +59,11 @@ class K8sPod:
             status = None
 
         self._status = status
+
+    def map_unit_to_pvc(self):
+        if self.is_running:
+            return self._status['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
+        return None
 
     @property
     def is_ready(self):
@@ -79,3 +87,53 @@ class K8sPod:
         if not self._status:
             return False
         return self._status['status']['phase'] == 'Running'
+
+
+class K8sPvc:
+
+    def __init__(self, app_name):
+        self._app_name = app_name
+        self._status = None
+
+    def fetch(self):
+        namespace = os.environ["JUJU_MODEL_NAME"]
+
+        pods = K8sPod(self._app_name)
+
+        path = f'/api/v1/namespaces/{namespace}/persistentvolumeclaims?' \
+               f'labelSelector=juju-app={self._app_name}'
+
+        api_server = K8sApi()
+        response = api_server.get(path)
+
+        if response.get('kind', '') == 'PersistentVolumeClaimList' \
+                and response['items']:
+            status = next(
+                (i for i in response['items']
+                 if i['metadata']['name'] == pods.map_unit_to_pvc()),
+                None
+            )
+        else:
+            status = None
+
+        self._status = status
+
+    def delete(self):
+        namespace = os.environ["JUJU_MODEL_NAME"]
+
+        if self.is_running:
+            pvc_name = self._status['metadata']['name']
+            path = f'/api/v1/namespaces/{namespace}/' \
+                   f'persistentvolumeclaims/{pvc_name}'
+
+            api_server = K8sApi()
+            api_server.delete(path)
+
+    @property
+    def is_running(self):
+        # pending bound lost
+        if not self._status:
+            self.fetch()
+        if not self._status:
+            return False
+        return self._status['status']['phase'] == 'Bound'

--- a/src/observers.py
+++ b/src/observers.py
@@ -40,7 +40,8 @@ class ConfigChangeObserver(BaseObserver):
                 return
 
         if not self._framework.unit_is_leader:
-            self._framework.unit_status_set(WaitingStatus('Waiting for leader'))
+            self._framework.unit_status_set(
+                WaitingStatus('Waiting for leader'))
             logger.info('Delegating pod configuration to the leader')
             return
 
@@ -54,6 +55,19 @@ class ConfigChangeObserver(BaseObserver):
             return
         self._framework.unit_status_set(MaintenanceStatus('Pod is not ready'))
         logger.info('Pod is not ready')
+
+
+class RemovalObserver(BaseObserver):
+
+    def __init__(self, framework, resources, pod, pvc, builder):
+        super().__init__(framework, resources, pod, builder)
+        self._pvc = pvc
+
+    def handle(self, event):
+        if not self._pod.is_ready:
+            logger.info('Pod deleted, removing remains')
+        self._builder.demolish()
+        logger.info('Pvc cleaned up')
 
 
 class RelationObserver(BaseObserver):

--- a/src/observers.py
+++ b/src/observers.py
@@ -40,7 +40,7 @@ class ConfigChangeObserver(BaseObserver):
                 return
 
         if not self._framework.unit_is_leader:
-            self._framework.unit_status_set(WaitingStatus('Not the leader'))
+            self._framework.unit_status_set(WaitingStatus('Waiting for leader'))
             logger.info('Delegating pod configuration to the leader')
             return
 


### PR DESCRIPTION
In order to remove mongodb pvc in scaling down process action needs to be run against the last unit:
```bash
juju run-action mongodb-k8s/2 remove-pvc
juju remove-unit -n 1 mongodb-k8s
```
This will start pvc removal and after that scaling down will not leave mongodb pvcs in 'terminating' state.